### PR TITLE
Include userInfo in failure event

### DIFF
--- a/mobile/ios/Classes/ComAppersonlabsGigyaModule.m
+++ b/mobile/ios/Classes/ComAppersonlabsGigyaModule.m
@@ -160,7 +160,6 @@
             [self _fireEventToListener:@"success" withObject:params listener:success thisObject:nil];
         }
         if (error && failure) {
-          NSLog(@"[DEBUG] failed login userInfo %@", error.userInfo);
           NSDictionary * params = @{ @"code": [NSNumber numberWithInteger:error.code], @"error": error.description, @"userInfo":error.userInfo };
             [self _fireEventToListener:@"failure" withObject:params listener:failure thisObject:nil];
         }

--- a/mobile/ios/Classes/ComAppersonlabsGigyaModule.m
+++ b/mobile/ios/Classes/ComAppersonlabsGigyaModule.m
@@ -160,7 +160,8 @@
             [self _fireEventToListener:@"success" withObject:params listener:success thisObject:nil];
         }
         if (error && failure) {
-            NSDictionary * params = @{ @"code": [NSNumber numberWithInteger:error.code], @"error": error.description };
+          NSLog(@"[DEBUG] failed login userInfo %@", error.userInfo);
+          NSDictionary * params = @{ @"code": [NSNumber numberWithInteger:error.code], @"error": error.description, @"userInfo":error.userInfo };
             [self _fireEventToListener:@"failure" withObject:params listener:failure thisObject:nil];
         }
      }];


### PR DESCRIPTION
Hi.

On failure, we need access to the `userInfo` object that's passed in the event object. Specifically, we needed the regToken in order to communicate with Gigya API's and determine why we failed. I've just added the userInfo object to the event being fired.

See:
http://wikifiles.gigya.com/SDKs/iPhone/doc/html/Classes/Gigya.html#//api/name/loginToProvider:parameters:completionHandler:

Specifically this bit:
>_handler_
>> A completion handler that will be invoked when the login process is finished. The handler should have the signature (GSUser *user, NSError *error). If the login was successful, the error parameter will be nil. Otherwise, you can check the error.code (see GSErrorCode) __or error.userInfo__ to learn why it failed.

Thanks so much,
Shad